### PR TITLE
feat: Add reading time and display all posts on landing page

### DIFF
--- a/_includes/reading_time.html
+++ b/_includes/reading_time.html
@@ -1,0 +1,6 @@
+{%- assign words = include.content | number_of_words -%}
+{%- if words < 200 -%}
+  1 min read
+{%- else -%}
+  {{ words | divided_by: 200 | round }} min read
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,51 @@
+---
+layout: base
+---
+<article class="post h-entry" itemscope itemtype="http://schema.org/BlogPosting">
+
+  <header class="post-header">
+    <h1 class="post-title p-name" itemprop="name headline">{{ page.title | escape }}</h1>
+    <div class="post-meta">
+      {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+      {% assign pdate = page.date | date_to_xmlschema %}
+      {%- if page.modified_date %}<span class="meta-label">Published:</span>{% endif %}
+      <time class="dt-published" datetime="{{ pdate }}" itemprop="datePublished">
+        {{ pdate | date: date_format }}
+      </time>
+      {%- if page.modified_date -%}
+        <span class="bullet-divider">•</span>
+        <span class="meta-label">Updated:</span>
+        {%- assign mdate = page.modified_date | date_to_xmlschema %}
+        <time class="dt-modified" datetime="{{ mdate }}" itemprop="dateModified">
+          {{ mdate | date: date_format }}
+        </time>
+      {%- endif -%}
+      <span class="bullet-divider">•</span> {% include reading_time.html content=page.content %}
+      {%- if page.author %}
+      <div class="{% unless page.modified_date %}force-inline {% endunless %}post-authors">
+        {%- for author in page.author %}
+          <span itemprop="author" itemscope itemtype="http://schema.org/Person">
+            <span class="p-author h-card" itemprop="name">{{ author }}</span></span>
+          {%- if forloop.last == false %}, {% endif -%}
+        {% endfor %}
+      </div>
+      {%- endif %}
+    </div>
+  </header>
+
+  <div class="post-content e-content" itemprop="articleBody">
+    {{ content }}
+  </div>
+
+  {% if jekyll.environment == 'production' -%}
+    {% if page.comments == false -%}
+    <div class="comments-disabled-message">
+      Comments have been disabled for this post.
+    </div>
+    {% else -%}
+      {%- include comments.html -%}
+    {% endif -%}
+  {% endif -%}
+
+  <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
+</article>

--- a/blog.md
+++ b/blog.md
@@ -8,7 +8,7 @@ permalink: /blog/
 
 {% for post in site.posts %}
 ## [{{ post.title }}]({{ post.url | relative_url }})
-{{ post.date | date: "%B %-d, %Y" }}
+{{ post.date | date: "%B %-d, %Y" }} - {% include reading_time.html content=post.content %}
 
 {{ post.excerpt }}
 

--- a/index.md
+++ b/index.md
@@ -9,6 +9,6 @@ This is my personal website where I share my thoughts and experiences.
 
 ## Recent Posts
 
-{% for post in site.posts limit:5 %}
-- [{{ post.title }}]({{ post.url | relative_url }}) - {{ post.date | date: "%B %-d, %Y" }}
+{% for post in site.posts %}
+- [{{ post.title }}]({{ post.url | relative_url }}) - {{ post.date | date: "%B %-d, %Y" }} - {% include reading_time.html content=post.content %}
 {% endfor %} 


### PR DESCRIPTION
This commit introduces two main enhancements:

1.  Estimated Reading Time:
    - A new include `_includes/reading_time.html` calculates and displays the estimated reading time for blog posts (based on 200 words per minute).
    - Reading time is now displayed on:
        - The landing page list of posts.
        - The dedicated blog page list (`/blog/`). - Individual blog post pages (via an overridden `_layouts/post.html`).

2.  Landing Page Post Listing:
    - The landing page (`index.md`) now displays all blog posts, instead of being limited to the 5 most recent.

These changes improve your experience by providing more content visibility on the landing page and offering readers an estimate of how long an article will take to read.